### PR TITLE
A clean fix of the encoding issue

### DIFF
--- a/cashaddr_test.go
+++ b/cashaddr_test.go
@@ -16,7 +16,7 @@ var valid []string = []string {
 
 func TestValid(t *testing.T) {
 	for _, s := range valid {
-		_, _, err := DecodeCashAddr(s)
+		_, _, err := DecodeCashAddress(s)
 		if err != nil {
 			t.Error(err)
 		}
@@ -38,7 +38,7 @@ var Invalid []string = []string {
 
 func TestInvalid(t *testing.T) {
 	for _, s := range Invalid {
-		_, _, err := DecodeCashAddr(s)
+		_, _, err := DecodeCashAddress(s)
 		if err == nil {
 			t.Error("Failed to error on invalid string")
 		}
@@ -47,27 +47,27 @@ func TestInvalid(t *testing.T) {
 
 func TestDecodeCashAddress(t *testing.T) {
 	// Mainnet
-	addr, err := DecodeCashAddress("bitcoincash:qpzry9x8gf2tvdw0s3jn5grmq650p", &chaincfg.MainNetParams)
+	addr, err := DecodeAddress("bitcoincash:qr95sy3j9xwd2ap32xkykttr4cvcu7as4y0qverfuy", &chaincfg.MainNetParams)
 	if err != nil {
 		t.Error(err)
 	}
-	if addr.String() != "bitcoincash:qpzry9x8gf2tvdw0s3jn5grmq650p" {
+	if addr.String() != "bitcoincash:qr95sy3j9xwd2ap32xkykttr4cvcu7as4y0qverfuy" {
 		t.Error("Address decoding error")
 	}
 	// Testnet
-	addr, err = DecodeCashAddress("bchtest:qpzry9x8gf2tvdw0s3jn5839nranq", &chaincfg.TestNet3Params)
+	addr, err = DecodeAddress("bchtest:qr95sy3j9xwd2ap32xkykttr4cvcu7as4ytjg7p7mc", &chaincfg.TestNet3Params)
 	if err != nil {
 		t.Error(err)
 	}
-	if addr.String() != "bchtest:qpzry9x8gf2tvdw0s3jn5839nranq" {
+	if addr.String() != "bchtest:qr95sy3j9xwd2ap32xkykttr4cvcu7as4ytjg7p7mc" {
 		t.Error("Address decoding error")
 	}
 	// Regtest
-	addr, err = DecodeCashAddress("bchreg:qpzry9x8gf2tvdw0s3jn5tgutzngm", &chaincfg.RegressionNetParams)
+	addr, err = DecodeAddress("bchreg:qr95sy3j9xwd2ap32xkykttr4cvcu7as4y3w7lzdc7", &chaincfg.RegressionNetParams)
 	if err != nil {
 		t.Error(err)
 	}
-	if addr.String() != "bchreg:qpzry9x8gf2tvdw0s3jn5tgutzngm" {
+	if addr.String() != "bchreg:qr95sy3j9xwd2ap32xkykttr4cvcu7as4y3w7lzdc7" {
 		t.Error("Address decoding error")
 	}
 }
@@ -88,7 +88,7 @@ func TestCashAddressPubKeyHash_EncodeAddress(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if addr.String() != "bchtest:qpzry9x8gf2tvdw0s3jn5wzx48p70" {
+	if addr.String() != "bchtest:qr95sy3j9xwd2ap32xkykttr4cvcu7as4ytjg7p7mc" {
 		t.Error("Address decoding error")
 	}
 	// Regtest
@@ -96,7 +96,7 @@ func TestCashAddressPubKeyHash_EncodeAddress(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if addr.String() != "bchreg:qpzry9x8gf2tvdw0s3jn5yk7zka9p" {
+	if addr.String() != "bchreg:qr95sy3j9xwd2ap32xkykttr4cvcu7as4y3w7lzdc7" {
 		t.Error("Address decoding error")
 	}
 }
@@ -117,7 +117,7 @@ func TestCashAddressScriptHash_EncodeAddress(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if addr.String() != "bchtest:gpzry9x8gf2tvdw0s3jn5l6cq5ykc" {
+	if addr.String() != "bchtest:ppm2qsznhks23z7629mms6s4cwef74vcwvhanqgjxu" {
 		t.Error("Address decoding error")
 	}
 	// Regtest
@@ -125,7 +125,7 @@ func TestCashAddressScriptHash_EncodeAddress(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if addr.String() != "bchreg:gpzry9x8gf2tvdw0s3jn54wqh9cdk" {
+	if addr.String() != "bchreg:ppm2qsznhks23z7629mms6s4cwef74vcwvdp9ptp96" {
 		t.Error("Address decoding error")
 	}
 }

--- a/cashaddr_test.go
+++ b/cashaddr_test.go
@@ -16,7 +16,7 @@ var valid []string = []string {
 
 func TestValid(t *testing.T) {
 	for _, s := range valid {
-		_, _, err := Decode(s)
+		_, _, err := DecodeCashAddr(s)
 		if err != nil {
 			t.Error(err)
 		}
@@ -38,16 +38,16 @@ var Invalid []string = []string {
 
 func TestInvalid(t *testing.T) {
 	for _, s := range Invalid {
-		_, _, err := Decode(s)
+		_, _, err := DecodeCashAddr(s)
 		if err == nil {
 			t.Error("Failed to error on invalid string")
 		}
 	}
 }
 
-func TestDecodeAddress(t *testing.T) {
+func TestDecodeCashAddress(t *testing.T) {
 	// Mainnet
-	addr, err := DecodeAddress("bitcoincash:qpzry9x8gf2tvdw0s3jn5grmq650p", &chaincfg.MainNetParams)
+	addr, err := DecodeCashAddress("bitcoincash:qpzry9x8gf2tvdw0s3jn5grmq650p", &chaincfg.MainNetParams)
 	if err != nil {
 		t.Error(err)
 	}
@@ -55,7 +55,7 @@ func TestDecodeAddress(t *testing.T) {
 		t.Error("Address decoding error")
 	}
 	// Testnet
-	addr, err = DecodeAddress("bchtest:qpzry9x8gf2tvdw0s3jn5839nranq", &chaincfg.TestNet3Params)
+	addr, err = DecodeCashAddress("bchtest:qpzry9x8gf2tvdw0s3jn5839nranq", &chaincfg.TestNet3Params)
 	if err != nil {
 		t.Error(err)
 	}
@@ -63,7 +63,7 @@ func TestDecodeAddress(t *testing.T) {
 		t.Error("Address decoding error")
 	}
 	// Regtest
-	addr, err = DecodeAddress("bchreg:qpzry9x8gf2tvdw0s3jn5tgutzngm", &chaincfg.RegressionNetParams)
+	addr, err = DecodeCashAddress("bchreg:qpzry9x8gf2tvdw0s3jn5tgutzngm", &chaincfg.RegressionNetParams)
 	if err != nil {
 		t.Error(err)
 	}
@@ -72,15 +72,15 @@ func TestDecodeAddress(t *testing.T) {
 	}
 }
 
-var dataElement = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
-
+var dataElement = []byte{203, 72, 18, 50, 41, 156, 213, 116, 49, 81, 172, 75, 45, 99, 174, 25, 142, 123, 176, 169}
+// Second address of https://github.com/Bitcoin-UAHF/spec/blob/master/cashaddr.md#examples-of-address-translation
 func TestCashAddressPubKeyHash_EncodeAddress(t *testing.T) {
 	// Mainnet
 	addr, err := NewCashAddressPubKeyHash(dataElement, &chaincfg.MainNetParams)
 	if err != nil {
 		t.Error(err)
 	}
-	if addr.String() != "bitcoincash:qpzry9x8gf2tvdw0s3jn5grmq650p" {
+	if addr.String() != "bitcoincash:qr95sy3j9xwd2ap32xkykttr4cvcu7as4y0qverfuy" {
 		t.Error("Address decoding error")
 	}
 	// Testnet
@@ -101,17 +101,19 @@ func TestCashAddressPubKeyHash_EncodeAddress(t *testing.T) {
 	}
 }
 
+var dataElement2 = []byte{118, 160, 64, 83, 189, 160, 168, 139, 218, 81, 119, 184, 106, 21, 195, 178, 159, 85, 152, 115}
+// 4th address of https://github.com/Bitcoin-UAHF/spec/blob/master/cashaddr.md#examples-of-address-translation
 func TestCashAddressScriptHash_EncodeAddress(t *testing.T) {
 	// Mainnet
-	addr, err := NewCashAddressScriptHashFromHash(dataElement, &chaincfg.MainNetParams)
+	addr, err := NewCashAddressScriptHashFromHash(dataElement2, &chaincfg.MainNetParams)
 	if err != nil {
 		t.Error(err)
 	}
-	if addr.String() != "bitcoincash:gpzry9x8gf2tvdw0s3jn5em94f38k" {
+	if addr.String() != "bitcoincash:ppm2qsznhks23z7629mms6s4cwef74vcwvn0h829pq" {
 		t.Error("Address decoding error")
 	}
 	// Testnet
-	addr, err = NewCashAddressScriptHashFromHash(dataElement, &chaincfg.TestNet3Params)
+	addr, err = NewCashAddressScriptHashFromHash(dataElement2, &chaincfg.TestNet3Params)
 	if err != nil {
 		t.Error(err)
 	}
@@ -119,7 +121,7 @@ func TestCashAddressScriptHash_EncodeAddress(t *testing.T) {
 		t.Error("Address decoding error")
 	}
 	// Regtest
-	addr, err = NewCashAddressScriptHashFromHash(dataElement, &chaincfg.RegressionNetParams)
+	addr, err = NewCashAddressScriptHashFromHash(dataElement2, &chaincfg.RegressionNetParams)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
# What this pull request does

- Replaces the addresses in tests with the ones in https://github.com/Bitcoin-UAHF/spec/blob/master/cashaddr.md#examples-of-address-translation
- Adds `CashAddress` to ambiguous names
- Safely fixes the encoding issue
- Fix tests with actually valid ones!

(The source code had https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/src/cashaddr.cpp but it lacked of https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/src/cashaddrenc.cpp . The Pull Request fixes that. It was what you missed)

Yes, I'm sure that this Pull Request does this right.

Tested decode, encode, and everything. All tests pass!